### PR TITLE
Add USDT dominance pipeline skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# aibot
+# USDT Dominance Signal Confirmation System
+
+This repository contains a basic implementation of a multi‑stage analytics pipeline that fetches USDT dominance data alongside Binance coin prices, computes correlations, classifies trading signals and provides a Streamlit dashboard.
+
+## Requirements
+
+- Python 3.11+
+- `pandas`, `yfinance`, `ccxt`, `scipy`, `streamlit`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the pipeline step by step:
+
+```bash
+python fetch_data.py
+python compute_signals.py
+python compute_classification.py
+python backtest.py
+streamlit run app/app.py
+```
+
+CSV data is written to the `data/` directory.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,37 @@
+import os
+import streamlit as st
+import pandas as pd
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+st.title('USDT Dominance Signal Dashboard')
+
+signals_path = os.path.join(DATA_DIR, 'signals_summary.csv')
+class_path = os.path.join(DATA_DIR, 'classification_summary.csv')
+backtest_path = os.path.join(DATA_DIR, 'backtest_results.csv')
+
+if not os.path.exists(signals_path):
+    st.warning('No signals data found.')
+    st.stop()
+
+signals = pd.read_csv(signals_path)
+classes = pd.read_csv(class_path) if os.path.exists(class_path) else pd.DataFrame()
+backtest = pd.read_csv(backtest_path) if os.path.exists(backtest_path) else pd.DataFrame()
+
+symbols = sorted(signals['symbol'].unique())
+timeframes = sorted(signals['timeframe'].unique())
+
+symbol = st.selectbox('Symbol', symbols)
+timeframe = st.selectbox('Timeframe', timeframes)
+
+filtered = signals[(signals['symbol'] == symbol) & (signals['timeframe'] == timeframe)]
+st.subheader('Correlation Signals')
+st.write(filtered)
+
+if not classes.empty:
+    st.subheader('Classified Signals')
+    st.write(classes[(classes['symbol'] == symbol) & (classes['timeframe'] == timeframe)])
+
+if not backtest.empty:
+    st.subheader('Backtest Results')
+    st.write(backtest[backtest['symbol'] == symbol])

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,34 @@
+"""Simple backtesting engine for classified signals."""
+
+from __future__ import annotations
+
+import os
+import pandas as pd
+
+DATA_DIR = "data"
+
+
+def simulate_trade(row: pd.Series) -> float:
+    entry = row["entry"]
+    exit_price = row["exit"]
+    if row["signal"] == "long":
+        return (exit_price - entry) / entry
+    elif row["signal"] == "short":
+        return (entry - exit_price) / entry
+    return 0.0
+
+
+def main() -> None:
+    path = os.path.join(DATA_DIR, "classification_summary.csv")
+    if not os.path.exists(path):
+        print("No classification data found")
+        return
+    df = pd.read_csv(path)
+    df["return"] = df.apply(simulate_trade, axis=1)
+    summary = df.groupby("timeframe")["return"].mean().reset_index()
+    df.to_csv(os.path.join(DATA_DIR, "backtest_results.csv"), index=False)
+    summary.to_csv(os.path.join(DATA_DIR, "backtest_summary.csv"), index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/compute_classification.py
+++ b/compute_classification.py
@@ -1,0 +1,66 @@
+"""Classify signals into long/short positions with TP/SL."""
+
+from __future__ import annotations
+
+import os
+import pandas as pd
+
+DATA_DIR = "data"
+THRESHOLD = 0.3
+TP_PCT = 0.02
+SL_PCT = 0.01
+
+
+def load_price(symbol: str, tf: str) -> pd.DataFrame:
+    path = os.path.join(DATA_DIR, f"{symbol}_{tf}.csv")
+    return pd.read_csv(path, parse_dates=["datetime"])
+
+
+def classify_signal(row: pd.Series) -> pd.Series:
+    corr = row["correlation"]
+    if corr <= -THRESHOLD:
+        signal = "long"
+    elif corr >= THRESHOLD:
+        signal = "short"
+    else:
+        signal = "neutral"
+    return pd.Series({"signal": signal, "confidence": abs(corr)})
+
+
+def compute_entries(df: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for _, row in df.iterrows():
+        price_df = load_price(row.symbol, row.timeframe)
+        idx = price_df[price_df["datetime"] == pd.to_datetime(row.date)].index
+        if len(idx) == 0 or idx[0] + 1 >= len(price_df):
+            continue
+        next_bar = price_df.loc[idx[0] + 1]
+        entry = next_bar["open"]
+        exit_price = next_bar["close"]
+        tp = entry * (1 + TP_PCT)
+        sl = entry * (1 - SL_PCT)
+        rows.append({
+            "timeframe": row.timeframe,
+            "symbol": row.symbol,
+            "signal": row.signal,
+            "confidence": row.confidence,
+            "entry": entry,
+            "exit": exit_price,
+            "tp": tp,
+            "sl": sl,
+        })
+    return pd.DataFrame(rows)
+
+
+def main() -> None:
+    path = os.path.join(DATA_DIR, "signals_summary.csv")
+    df = pd.read_csv(path, parse_dates=["date"])
+    cls = df.apply(classify_signal, axis=1)
+    df = pd.concat([df, cls], axis=1)
+    df = df[df["signal"] != "neutral"]
+    result = compute_entries(df)
+    result.to_csv(os.path.join(DATA_DIR, "classification_summary.csv"), index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/compute_signals.py
+++ b/compute_signals.py
@@ -1,0 +1,68 @@
+"""Compute Pearson correlations between coins and USDT dominance."""
+
+from __future__ import annotations
+
+import os
+import glob
+from typing import List
+
+import pandas as pd
+from scipy.stats import pearsonr
+
+DATA_DIR = "data"
+TIMEFRAMES = ["15m", "2h", "4h", "1d", "1wk"]
+
+
+def load_usdt(tf: str) -> pd.Series:
+    path = os.path.join(DATA_DIR, f"usdt_dominance_{tf}.csv")
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    df = pd.read_csv(path, parse_dates=["datetime"])
+    return df.set_index("datetime")["close"]
+
+
+def load_coin(path: str) -> pd.Series:
+    df = pd.read_csv(path, parse_dates=["datetime"])
+    return df.set_index("datetime")["close"]
+
+
+def compute_for_tf(tf: str) -> pd.DataFrame:
+    usdt = load_usdt(tf)
+    rows = []
+    pattern = os.path.join(DATA_DIR, f"*_{tf}.csv")
+    for path in glob.glob(pattern):
+        if path.startswith(os.path.join(DATA_DIR, "usdt_dominance")):
+            continue
+        symbol = os.path.basename(path).replace(f"_{tf}.csv", "")
+        price = load_coin(path)
+        joined = pd.concat([price, usdt], axis=1, join="inner").dropna()
+        if len(joined) < 7:
+            continue
+        corr, _ = pearsonr(joined.iloc[:, 0], joined.iloc[:, 1])
+        rows.append({
+            "timeframe": tf,
+            "symbol": symbol,
+            "date": joined.index[-1],
+            "correlation": corr,
+        })
+    df = pd.DataFrame(rows)
+    path_out = os.path.join(DATA_DIR, f"signals_summary_{tf}.csv")
+    df.to_csv(path_out, index=False)
+    return df
+
+
+def main() -> None:
+    frames: List[pd.DataFrame] = []
+    for tf in TIMEFRAMES:
+        try:
+            df = compute_for_tf(tf)
+            frames.append(df)
+        except FileNotFoundError:
+            print(f"Missing USDT data for {tf}, skipping")
+    if frames:
+        master = pd.concat(frames, ignore_index=True)
+        master.to_csv(os.path.join(DATA_DIR, "signals_summary.csv"), index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -1,0 +1,104 @@
+"""Fetch USDT dominance and Binance OHLCV data."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List, Dict
+
+import pandas as pd
+import yfinance as yf
+import ccxt
+
+DATA_DIR = "data"
+
+TIMEFRAMES = {
+    "15m": {"yf_interval": "15m", "period": "60d"},
+    "2h": {"yf_interval": "60m", "period": "60d", "resample": "2h"},
+    "4h": {"yf_interval": "60m", "period": "60d", "resample": "4h"},
+    "1d": {"yf_interval": "1d", "start": "2019-01-01"},
+    "1wk": {"yf_interval": "1wk", "start": "2019-01-01"},
+}
+
+BINANCE_LIMIT = 500
+
+
+def ensure_data_dir() -> None:
+    os.makedirs(DATA_DIR, exist_ok=True)
+
+
+def fetch_usdt_dominance(tf: str) -> pd.DataFrame:
+    params = TIMEFRAMES[tf]
+    interval = params["yf_interval"]
+    kwargs: Dict[str, str] = {}
+    if "period" in params:
+        kwargs["period"] = params["period"]
+    if "start" in params:
+        kwargs["start"] = params["start"]
+    df = yf.download("USDT-USD", interval=interval, **kwargs)
+
+    if df.empty:
+        return df
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(1)
+    df = df.rename(columns={"Adj Close": "close"})
+    df = df[["Open", "High", "Low", "close", "Volume"]]
+    df.columns = ["open", "high", "low", "close", "volume"]
+
+    if "resample" in params:
+        df = df.resample(params["resample"]).agg({
+            "open": "first",
+            "high": "max",
+            "low": "min",
+            "close": "last",
+            "volume": "sum",
+        })
+
+    df = df.reset_index().rename(columns={"index": "datetime"})
+    df["datetime"] = pd.to_datetime(df["datetime"]).dt.tz_localize(None)
+    df = df.dropna()
+
+    path = os.path.join(DATA_DIR, f"usdt_dominance_{tf}.csv")
+    df.to_csv(path, index=False)
+    return df
+
+
+def fetch_binance_symbols(limit: int = 50) -> List[str]:
+    exchange = ccxt.binance()
+    markets = exchange.load_markets()
+    symbols = [s for s in markets if s.endswith("/USDT")]
+    return symbols[:limit]
+
+
+def fetch_coin(symbol: str, tf: str) -> pd.DataFrame:
+    exchange = ccxt.binance()
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe=tf, limit=BINANCE_LIMIT)
+    df = pd.DataFrame(ohlcv, columns=["datetime", "open", "high", "low", "close", "volume"])
+    df["datetime"] = pd.to_datetime(df["datetime"], unit="ms")
+    df["datetime"] = df["datetime"].dt.tz_localize(None)
+    df = df.dropna()
+    path = os.path.join(DATA_DIR, f"{symbol.replace('/', '')}_{tf}.csv")
+    df.to_csv(path, index=False)
+    return df
+
+
+def main() -> None:
+    ensure_data_dir()
+    for tf in TIMEFRAMES:
+        print(f"Fetching USDT dominance {tf}...")
+        usdt_df = fetch_usdt_dominance(tf)
+        if usdt_df.empty:
+            print(f"Warning: no data for timeframe {tf}")
+    symbols = fetch_binance_symbols()
+    for symbol in symbols:
+        for tf in TIMEFRAMES:
+            print(f"Fetching {symbol} {tf}...")
+            try:
+                fetch_coin(symbol, tf)
+            except Exception as e:
+                print(f"Failed to fetch {symbol} {tf}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+yfinance
+ccxt
+scipy
+streamlit


### PR DESCRIPTION
## Summary
- add README instructions and requirements
- implement data fetcher for USDT dominance and Binance symbols
- compute correlation signals
- classify signals and generate simple backtest
- provide Streamlit dashboard

## Testing
- `python3 -m py_compile fetch_data.py compute_signals.py compute_classification.py backtest.py app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687021204640832a8565387a0040ea4e